### PR TITLE
Fix patch to work with current version from Github.

### DIFF
--- a/sci-electronics/yosys/files/yosys-9999-makefile.patch
+++ b/sci-electronics/yosys/files/yosys-9999-makefile.patch
@@ -1,29 +1,37 @@
+From d3d565c7cdce50b67b0b4ab2b353effb99f4b5e2 Mon Sep 17 00:00:00 2001
+From: "Luke A. Guest" <laguest@archeia.com>
+Date: Sun, 20 Oct 2024 16:56:24 +0100
+Subject: [PATCH] Fix the patch for the latest version.
+
+---
+ Makefile | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
 diff --git a/Makefile b/Makefile
-index 4f7f94cf1..a4b6f3fbb 100644
+index 5be8c64e9..b772e1a49 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -166,7 +166,7 @@ bumpversion:
- # will remove the 'abc' directory and you do not want to accidentally
- # delete your work on ABC..
- ABCREV = bb64142
--ABCPULL = 1
-+ABCPULL = 0
- ABCURL ?= https://github.com/YosysHQ/abc
- ABCMKARGS = CC="$(CXX)" CXX="$(CXX)" ABC_USE_LIBSTDCXX=1 ABC_USE_NAMESPACE=abc VERBOSE=$(Q)
- 
-@@ -822,11 +822,11 @@ ifeq ($(ABCREV),default)
- .PHONY: abc/libabc-$(ABCREV).a
- endif
- 
--$(PROGRAM_PREFIX)yosys-abc$(EXE): abc/abc-$(ABCREV)$(EXE)
--	$(P) cp abc/abc-$(ABCREV)$(EXE) $(PROGRAM_PREFIX)yosys-abc$(EXE)
+@@ -817,15 +817,15 @@ check-git-abc:
+ 		exit 1; \
+ 	fi
+
+-abc/abc$(EXE) abc/libabc.a: | check-git-abc
++abc/abc$(EXE) abc/libabc.a: #| check-git-abc
+ 	$(P)
+ 	$(Q) mkdir -p abc && $(MAKE) -C $(PROGRAM_PREFIX)abc -f "$(realpath $(YOSYS_SRC)/abc/Makefile)" ABCSRC="$(realpath $(YOSYS_SRC)/abc/)" $(S) $(ABCMKARGS) $(if $(filter %.a,$@),PROG="abc",PROG="abc$(EXE)") MSG_PREFIX="$(eval P_OFFSET = 5)$(call P_SHOW)$(eval P_OFFSET = 10) ABC: " $(if $(filter %.a,$@),libabc.a)
+
+-$(PROGRAM_PREFIX)yosys-abc$(EXE): abc/abc$(EXE)
+-	$(P) cp $< $(PROGRAM_PREFIX)yosys-abc$(EXE)
 +$(PROGRAM_PREFIX)yosys-abc$(EXE): /usr/bin/abc$(EXE)
 +	$(P) cp /usr/bin/abc$(EXE) $(PROGRAM_PREFIX)yosys-abc$(EXE)
- 
--$(PROGRAM_PREFIX)yosys-libabc.a: abc/libabc-$(ABCREV).a
--	$(P) cp abc/libabc-$(ABCREV).a $(PROGRAM_PREFIX)yosys-libabc.a
+
+-$(PROGRAM_PREFIX)yosys-libabc.a: abc/libabc.a
+-	$(P) cp $< $(PROGRAM_PREFIX)yosys-libabc.a
 +$(PROGRAM_PREFIX)yosys-libabc.a: /usr/lib64/abc$(EXE)
 +	$(P) cp /usr/lib64/libabc.a $(PROGRAM_PREFIX)yosys-libabc.a
- 
+
  ifneq ($(SEED),)
  SEEDOPT="-S $(SEED)"
+--
+2.45.2
+


### PR DESCRIPTION
Currently Yosys doesn't compile, this patch fixes that.

Ideally, this should link with the libabc built from the other ebuild. Add TODO.